### PR TITLE
fix limit param key name in update_existing_entries

### DIFF
--- a/scm/process.py
+++ b/scm/process.py
@@ -293,7 +293,7 @@ class SCMObjectManager:
                 scope_type, scope_value = scope_param.lstrip('&').split('=')
                 
                 # Construct the params dictionary for the API call
-                params = {scope_type: scope_value, limit: limit}
+                params = {scope_type: scope_value, 'limit': limit}
                 
                 current_objects = self.api_handler.get(entry_class.get_endpoint(), params=params)
                 current_object = next((obj for obj in current_objects if obj['name'] == entry['name']), None)


### PR DESCRIPTION
## Description

param dict key should be set as string

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
